### PR TITLE
Added Metadata Replacement in output message

### DIFF
--- a/gerrit/README.md
+++ b/gerrit/README.md
@@ -70,11 +70,17 @@ The given revision is updated with the given message and/or label(s).
   just the resource name.
 
 * `message`: A message to be posted as a comment on the given revision.
+  The message can contain build metadata variables. (e.g.: $BUILD_ID)
+  See the [Concourse.CI Metadata Documentation](https://concourse.ci/implementing-resources.html#section_resource-metadata
+  for a complete list of variables.
 
 * `message_file`: Path to a file containing a message to be posted as a comment
   on the given revision. This overrides `message` *unless* reading
   `message_file` fails, in which case `message` is used instead. If reading
   `message_file` fails and `message` is not specified then the `put` will fail.
+  The message can contain build metadata variables. (e.g.: $BUILD_ID)
+  See the [Concourse.CI Metadata Documentation](https://concourse.ci/implementing-resources.html#section_resource-metadata
+  for a complete list of variables.
 
 * `labels`: A map of label names to integers to set on the given revision, e.g.:
   `{Verified: 1}`.

--- a/gerrit/README.md
+++ b/gerrit/README.md
@@ -70,7 +70,7 @@ The given revision is updated with the given message and/or label(s).
   just the resource name.
 
 * `message`: A message to be posted as a comment on the given revision.
-  The message can contain build metadata variables. (e.g.: $BUILD_ID)
+  The message can contain build metadata variables. (e.g.: ${BUILD_ID})
   See the [Concourse.CI Metadata Documentation](https://concourse.ci/implementing-resources.html#section_resource-metadata
   for a complete list of variables.
 
@@ -78,7 +78,7 @@ The given revision is updated with the given message and/or label(s).
   on the given revision. This overrides `message` *unless* reading
   `message_file` fails, in which case `message` is used instead. If reading
   `message_file` fails and `message` is not specified then the `put` will fail.
-  The message can contain build metadata variables. (e.g.: $BUILD_ID)
+  The message can contain build metadata variables. (e.g.: ${BUILD_ID})
   See the [Concourse.CI Metadata Documentation](https://concourse.ci/implementing-resources.html#section_resource-metadata
   for a complete list of variables.
 

--- a/gerrit/out.go
+++ b/gerrit/out.go
@@ -84,12 +84,12 @@ func out(req resource.OutRequest) error {
 
 	// Replace environment variables in message
 	var variableTokens = map[string]string{
-		"$BUILD_ID":            os.Getenv("BUILD_ID"),
-		"$BUILD_NAME":          os.Getenv("BUILD_NAME"),
-		"$BUILD_JOB_NAME":      os.Getenv("BUILD_JOB_NAME"),
-		"$BUILD_PIPELINE_NAME": os.Getenv("BUILD_PIPELINE_NAME"),
-		"$BUILD_TEAM_NAME":     os.Getenv("BUILD_TEAM_NAME"),
-		"$ATC_EXTERNAL_URL":    os.Getenv("ATC_EXTERNAL_URL"),
+		"${BUILD_ID}":            os.Getenv("BUILD_ID"),
+		"${BUILD_NAME}":          os.Getenv("BUILD_NAME"),
+		"${BUILD_JOB_NAME}":      os.Getenv("BUILD_JOB_NAME"),
+		"${BUILD_PIPELINE_NAME}": os.Getenv("BUILD_PIPELINE_NAME"),
+		"${BUILD_TEAM_NAME}":     os.Getenv("BUILD_TEAM_NAME"),
+		"${ATC_EXTERNAL_URL}":    os.Getenv("ATC_EXTERNAL_URL"),
 	}
 
 	for k, v := range variableTokens {

--- a/gerrit/out.go
+++ b/gerrit/out.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"golang.org/x/build/gerrit"
 
@@ -78,6 +80,20 @@ func out(req resource.OutRequest) error {
 				log.Printf("using fallback message %q", message)
 			}
 		}
+	}
+
+	// Replace environment variables in message
+	var variableTokens = map[string]string{
+		"$BUILD_ID":            os.Getenv("BUILD_ID"),
+		"$BUILD_NAME":          os.Getenv("BUILD_NAME"),
+		"$BUILD_JOB_NAME":      os.Getenv("BUILD_JOB_NAME"),
+		"$BUILD_PIPELINE_NAME": os.Getenv("BUILD_PIPELINE_NAME"),
+		"$BUILD_TEAM_NAME":     os.Getenv("BUILD_TEAM_NAME"),
+		"$ATC_EXTERNAL_URL":    os.Getenv("ATC_EXTERNAL_URL"),
+	}
+
+	for k, v := range variableTokens {
+		message = strings.Replace(message, k, v, -1)
 	}
 
 	// Send review

--- a/gerrit/out_test.go
+++ b/gerrit/out_test.go
@@ -70,7 +70,7 @@ func TestOutMessageWithBuildId(t *testing.T) {
 	os.Setenv("BUILD_ID", environmentValue)
 
 	// Execute
-	testOut(t, Source{}, outParams{Message: "foo bar $BUILD_ID"})
+	testOut(t, Source{}, outParams{Message: "foo bar ${BUILD_ID}"})
 
 	// Verify
 	assert.Equal(t, "foo bar 1", testGerritLastReviewInput.Message)
@@ -82,7 +82,7 @@ func TestOutMessageWithBuildName(t *testing.T) {
 	os.Setenv("BUILD_NAME", environmentValue)
 
 	// Execute
-	testOut(t, Source{}, outParams{Message: "foo bar $BUILD_NAME"})
+	testOut(t, Source{}, outParams{Message: "foo bar ${BUILD_NAME}"})
 
 	// Verify
 	assert.Equal(t, "foo bar 1", testGerritLastReviewInput.Message)
@@ -94,7 +94,7 @@ func TestOutMessageWithBuildJobName(t *testing.T) {
 	os.Setenv("BUILD_JOB_NAME", environmentValue)
 
 	// Execute
-	testOut(t, Source{}, outParams{Message: "foo bar $BUILD_JOB_NAME"})
+	testOut(t, Source{}, outParams{Message: "foo bar ${BUILD_JOB_NAME}"})
 
 	// Verify
 	assert.Equal(t, "foo bar 1", testGerritLastReviewInput.Message)
@@ -106,7 +106,7 @@ func TestOutMessageWithBuildPipelineName(t *testing.T) {
 	os.Setenv("BUILD_PIPELINE_NAME", environmentValue)
 
 	// Execute
-	testOut(t, Source{}, outParams{Message: "foo bar $BUILD_PIPELINE_NAME"})
+	testOut(t, Source{}, outParams{Message: "foo bar ${BUILD_PIPELINE_NAME}"})
 
 	// Verify
 	assert.Equal(t, "foo bar 1", testGerritLastReviewInput.Message)
@@ -118,7 +118,7 @@ func TestOutMessageWithBuildTeamName(t *testing.T) {
 	os.Setenv("BUILD_TEAM_NAME", environmentValue)
 
 	// Execute
-	testOut(t, Source{}, outParams{Message: "foo bar $BUILD_TEAM_NAME"})
+	testOut(t, Source{}, outParams{Message: "foo bar ${BUILD_TEAM_NAME}"})
 
 	// Verify
 	assert.Equal(t, "foo bar 1", testGerritLastReviewInput.Message)
@@ -130,7 +130,7 @@ func TestOutMessageWithATCExternalUrl(t *testing.T) {
 	os.Setenv("ATC_EXTERNAL_URL", environmentValue)
 
 	// Execute
-	testOut(t, Source{}, outParams{Message: "foo bar $ATC_EXTERNAL_URL"})
+	testOut(t, Source{}, outParams{Message: "foo bar ${ATC_EXTERNAL_URL}"})
 
 	// Verify
 	assert.Equal(t, "foo bar 1", testGerritLastReviewInput.Message)
@@ -152,12 +152,12 @@ func TestOutMessageWithAllVariables(t *testing.T) {
 	os.Setenv("ATC_EXTERNAL_URL", atcExternalUrl)
 
 	// Execute
-	testOut(t, Source{}, outParams{Message: "foo bar $BUILD_ID $BUILD_NAME $BUILD_JOB_NAME $BUILD_PIPELINE_NAME $BUILD_TEAM_NAME $ATC_EXTERNAL_URL"})
+	testOut(t, Source{}, outParams{Message: "foo bar ${BUILD_ID} ${BUILD_NAME} ${BUILD_JOB_NAME} ${BUILD_PIPELINE_NAME} ${BUILD_TEAM_NAME} ${ATC_EXTERNAL_URL}"})
 
 	// Verify
 	assert.Equal(t, "foo bar 1 2 3 4 5 6", testGerritLastReviewInput.Message)
-
 }
+
 func TestOutMessageFile(t *testing.T) {
 	err := ioutil.WriteFile(
 		filepath.Join(testTempDir, "message.txt"),

--- a/gerrit/out_test.go
+++ b/gerrit/out_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -61,6 +62,78 @@ func TestOutVersion(t *testing.T) {
 func TestOutMessage(t *testing.T) {
 	testOut(t, Source{}, outParams{Message: "foo bar"})
 	assert.Equal(t, "foo bar", testGerritLastReviewInput.Message)
+}
+
+func TestOutMessageWithBuildId(t *testing.T) {
+	// Test Data
+	environmentValue := "1"
+	os.Setenv("BUILD_ID", environmentValue)
+
+	// Execute
+	testOut(t, Source{}, outParams{Message: "foo bar $BUILD_ID"})
+
+	// Verify
+	assert.Equal(t, "foo bar 1", testGerritLastReviewInput.Message)
+}
+
+func TestOutMessageWithBuildName(t *testing.T) {
+	// Test Data
+	environmentValue := "1"
+	os.Setenv("BUILD_NAME", environmentValue)
+
+	// Execute
+	testOut(t, Source{}, outParams{Message: "foo bar $BUILD_NAME"})
+
+	// Verify
+	assert.Equal(t, "foo bar 1", testGerritLastReviewInput.Message)
+}
+
+func TestOutMessageWithBuildJobName(t *testing.T) {
+	// Test Data
+	environmentValue := "1"
+	os.Setenv("BUILD_JOB_NAME", environmentValue)
+
+	// Execute
+	testOut(t, Source{}, outParams{Message: "foo bar $BUILD_JOB_NAME"})
+
+	// Verify
+	assert.Equal(t, "foo bar 1", testGerritLastReviewInput.Message)
+}
+
+func TestOutMessageWithBuildPipelineName(t *testing.T) {
+	// Test Data
+	environmentValue := "1"
+	os.Setenv("BUILD_PIPELINE_NAME", environmentValue)
+
+	// Execute
+	testOut(t, Source{}, outParams{Message: "foo bar $BUILD_PIPELINE_NAME"})
+
+	// Verify
+	assert.Equal(t, "foo bar 1", testGerritLastReviewInput.Message)
+}
+
+func TestOutMessageWithBuildTeamName(t *testing.T) {
+	// Test Data
+	environmentValue := "1"
+	os.Setenv("BUILD_TEAM_NAME", environmentValue)
+
+	// Execute
+	testOut(t, Source{}, outParams{Message: "foo bar $BUILD_TEAM_NAME"})
+
+	// Verify
+	assert.Equal(t, "foo bar 1", testGerritLastReviewInput.Message)
+}
+
+func TestOutMessageWithATCExternalUrl(t *testing.T) {
+	// Test Data
+	environmentValue := "1"
+	os.Setenv("ATC_EXTERNAL_URL", environmentValue)
+
+	// Execute
+	testOut(t, Source{}, outParams{Message: "foo bar $ATC_EXTERNAL_URL"})
+
+	// Verify
+	assert.Equal(t, "foo bar 1", testGerritLastReviewInput.Message)
 }
 
 func TestOutMessageFile(t *testing.T) {

--- a/gerrit/out_test.go
+++ b/gerrit/out_test.go
@@ -136,6 +136,28 @@ func TestOutMessageWithATCExternalUrl(t *testing.T) {
 	assert.Equal(t, "foo bar 1", testGerritLastReviewInput.Message)
 }
 
+func TestOutMessageWithAllVariables(t *testing.T) {
+	// Test Data
+	buildId := "1"
+	os.Setenv("BUILD_ID", buildId)
+	buildName := "2"
+	os.Setenv("BUILD_NAME", buildName)
+	buildJobName := "3"
+	os.Setenv("BUILD_JOB_NAME", buildJobName)
+	buildPipelineName := "4"
+	os.Setenv("BUILD_PIPELINE_NAME", buildPipelineName)
+	buildTeamName := "5"
+	os.Setenv("BUILD_TEAM_NAME", buildTeamName)
+	atcExternalUrl := "6"
+	os.Setenv("ATC_EXTERNAL_URL", atcExternalUrl)
+
+	// Execute
+	testOut(t, Source{}, outParams{Message: "foo bar $BUILD_ID $BUILD_NAME $BUILD_JOB_NAME $BUILD_PIPELINE_NAME $BUILD_TEAM_NAME $ATC_EXTERNAL_URL"})
+
+	// Verify
+	assert.Equal(t, "foo bar 1 2 3 4 5 6", testGerritLastReviewInput.Message)
+
+}
 func TestOutMessageFile(t *testing.T) {
 	err := ioutil.WriteFile(
 		filepath.Join(testTempDir, "message.txt"),


### PR DESCRIPTION
- Added Environment variable replacement in message according to
  the details specified here:
  https://concourse.ci/implementing-resources.html#section_resource-metadata
- Added Basic unit tests for the functionality
- Updated README Example

This PR implements functionality requested in #10 